### PR TITLE
Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "main": "gae-deploy.js",
   "scripts": {},
+  "files": [
+    "gae-deploy.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/kirillgroshkov/node-gae-deploy.git"


### PR DESCRIPTION
This prevents any files that the end-user doesnt need (for example [.editorconfig](https://github.com/kirillgroshkov/node-gae-deploy/blob/master/.editorconfig)) from being distributed with the npm package
